### PR TITLE
Feature: Strip Out Unused Strings

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -24,3 +24,6 @@ target_link_libraries(file_output zf_log)
 
 add_executable(args_eval args_eval.c)
 target_link_libraries(args_eval zf_log)
+
+add_executable(strip_log_messages strip_log_messages.c)
+target_link_libraries(strip_log_messages zf_log)

--- a/examples/strip_log_messages.c
+++ b/examples/strip_log_messages.c
@@ -1,0 +1,69 @@
+/*
+ * Example demonstrating stripping out log messages which would otherwise
+ * be unused.
+ *
+ * To test:
+ * 1. Set the log level as desired
+ * 2. Compile and run the application
+ * 3. Observe application output for logs below the desired log level
+ * 4. Use the `strings' application to search for the string at the desired log
+ *  level
+ * 4.1. example @ INFO log level:
+ *     $ strings strip_log_messages | egrep "[a-z] dump string"
+ *     i dump string
+ *     w dump string
+ *     e dump string
+ *     f dump string
+ *     $
+ *
+ * 5. Use the `strings' application to search for the string below the desired
+ *   log level
+ * 5.1. example @ INFO log level
+ *     $ strings strip_log_messages | egrep "[a-z] dump string"
+ *     i dump string
+ *     w dump string
+ *     e dump string
+ *     f dump string
+ *     $
+ *
+ * 6. Confirm that steps 4 & 5 also work for ZF_LOG*_MEM using the same
+ * technique
+ * 6.1. example @ INFO log level
+ *     $ strings strip_log_messages | egrep "[a-z]m %s"
+ *     im %s
+ *     wm %s
+ *     em %s
+ *     fm %s
+ *     $
+ *
+ */
+#include <stdio.h>
+#include <string.h>
+
+#define ZF_LOG_LEVEL ZF_LOG_INFO
+#include "zf_log.h"
+
+int main()
+{
+    char* dumpable_string = "dump string\0";
+
+    ZF_LOGV("v dump string");
+    ZF_LOGD("d dump string");
+    ZF_LOGI("i dump string");
+    ZF_LOGW("w dump string");
+    ZF_LOGE("e dump string");
+    ZF_LOGF("f dump string");
+
+    ZF_LOGV_MEM(dumpable_string, strlen(dumpable_string), "vm %s",
+                dumpable_string);
+    ZF_LOGD_MEM(dumpable_string, strlen(dumpable_string), "dm %s",
+                dumpable_string);
+    ZF_LOGI_MEM(dumpable_string, strlen(dumpable_string), "im %s",
+                dumpable_string);
+    ZF_LOGW_MEM(dumpable_string, strlen(dumpable_string), "wm %s",
+                dumpable_string);
+    ZF_LOGE_MEM(dumpable_string, strlen(dumpable_string), "em %s",
+                dumpable_string);
+    ZF_LOGF_MEM(dumpable_string, strlen(dumpable_string), "fm %s",
+                dumpable_string);
+}

--- a/zf_log/zf_log.h
+++ b/zf_log/zf_log.h
@@ -303,6 +303,24 @@
  */
 #define ZF_LOG_SECRETS (ZF_LOG_UNCENSORED == _ZF_LOG_CENSORING)
 
+/*
+ * If a log message would otherwise be unused, it can be stripped from the
+ * output binary by defining ZF_LOG_STRIP_UNUSED. This is achieved by changing
+ * the log macro to output a statement with no side effects. The default is not
+ * to strip unlogged messages. For ecample:
+ *
+ *   #define ZF_LOG_STRIP_UNUSED ZF_LOG_DO_STRIP_UNUSED
+ *
+ * This can help keep down file sizes where they are a premium and cut down on
+ * shipping dead code.
+ */
+#define ZF_LOG_DO_STRIP_UNUSED 0
+#define ZF_LOG_DO_NOT_STRIP_UNUSED 1
+
+#ifndef ZF_LOG_STRIP_UNUSED
+    #define ZF_LOG_STRIP_UNUSED ZF_LOG_DO_NOT_STRIP_UNUSED
+#endif
+
 /* Static (compile-time) initialization support allows to configure logging
  * before entering main() function. This mostly useful in C++ where functions
  * and methods could be called during initialization of global objects. Those
@@ -794,8 +812,12 @@ void _zf_log_write_mem_aux(
 
 static _ZF_LOG_INLINE void _zf_log_unused(const int dummy, ...) {(void)dummy;}
 
+#if ZF_LOG_STRIP_UNUSED == ZF_LOG_DO_STRIP_UNUSED
+#define _ZF_LOG_UNUSED(...) do {} while(0)
+#else
 #define _ZF_LOG_UNUSED(...) \
 		do { _ZF_LOG_NEVER _zf_log_unused(0, __VA_ARGS__); } _ZF_LOG_ONCE
+#endif
 
 #if ZF_LOG_ENABLED_VERBOSE
 	#define ZF_LOGV(...) \


### PR DESCRIPTION
This feature is designed to allow embedded developers to strip out unused logging code in their application. In keeping with the spirit of zf_log, it only targets the format string and and statements in the arguments list of an application in order to keep complexity to a minimum.

A functional example of the feature may be found under ```examples/strip_log_messages.c```.

I am open for comment from the maintainers and look forward to contributing to this project.