### PR TITLE
add a possability to use a zf_log_config.h

### DIFF
--- a/zf_log/zf_log.c
+++ b/zf_log/zf_log.c
@@ -1,3 +1,7 @@
+#ifdef ZF_LOG_CONFIG
+#include "zf_log_config.h"
+#endif
+
 /* When defined, Android log (android/log.h) will be used by default instead of
  * stderr (ignored on non-Android platforms). Date, time, pid and tid (context)
  * will be provided by Android log. Android log features will be used to output


### PR DESCRIPTION
So please can you add this to main line. -include does not work for every situation. And it would be great if i do not need to patch the source when checked out as submodule.

thx