### PR TITLE
fix include error for limits hearder

### DIFF
--- a/zf_log/zf_log.c
+++ b/zf_log/zf_log.c
@@ -310,7 +310,7 @@
 	#if defined(__linux__)
 		#include <linux/limits.h>
 	#else
-		#include <limits.h>
+		#include <sys/syslimits.h>
 	#endif
 #endif
 


### PR DESCRIPTION
For me the include was wrong. The old version also uses that include.